### PR TITLE
Remove spacing from `table`

### DIFF
--- a/summary.js
+++ b/summary.js
@@ -49,8 +49,6 @@ module.exports = function(results) {
         summaryLineArray.push(chalk[errorColor].bold(errorCount + ' ' + pluralize('error', errorCount) + '.'));
     }
 
-    return '\n'
-            + table([summaryLineArray])
-            + '\n';
+    return table([summaryLineArray]);
 
 };


### PR DESCRIPTION
This applies the following change.

![screenshot.png](http://i.imgur.com/J4LDAyT.png)

You can see in the second run it cleans up how gulp handles the summary. I'm not sure how this will behave in other environments/tooling so I'm happy to add this change via an option unless you want the PR as is :smile:
